### PR TITLE
Canvas oauth setup

### DIFF
--- a/frontend/views.py
+++ b/frontend/views.py
@@ -1,6 +1,9 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
-from canvas_oauth.oauth import get_oauth_token
+from rubric_visualization.decorators import require_canvas_oauth_token
 
-def index(request):
-    access_token = get_oauth_token(request)
+
+@login_required
+@require_canvas_oauth_token
+def index(request, **kwargs):
     return render(request, 'frontend/index.html')

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
-
+from canvas_oauth.oauth import get_oauth_token
 
 def index(request):
+    access_token = get_oauth_token(request)
     return render(request, 'frontend/index.html')

--- a/rubric_data/views.py
+++ b/rubric_data/views.py
@@ -1,24 +1,33 @@
-from django.shortcuts import render
 from django.http import JsonResponse
 from django.conf import settings
-
+from canvas_oauth.oauth import get_oauth_token
+from canvas_sdk.exceptions import CanvasAPIError
 from canvas_sdk.methods import submissions, assignments, courses
 from canvas_sdk.utils import get_all_list_data
 from canvas_sdk import RequestContext
+from rubric_visualization.decorators import api_login_required, api_canvas_oauth_token_exception
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 
+@api_canvas_oauth_token_exception
+@api_login_required
 def get_some_data(request):
-    request_context = RequestContext(
-        settings.SDK_OAUTH_TOKEN,
-        settings.CANVAS_URL,
-        per_page=100
-        )
-        
+    access_token = get_oauth_token(request)
+    request_context = RequestContext(**settings.CANVAS_SDK_SETTINGS, auth_token=access_token)
     course = 58055
-    
-    students = get_students_list(request_context, course)
-    assignments = get_assignments_list(request_context, course)
-    assignment_ids = [assignment['id'] for assignment in assignments]
+
+    try:
+        students = get_students_list(request_context, course)
+        assignments = get_assignments_list(request_context, course)
+    except CanvasAPIError as e:
+        logger.exception("Canvas API error")
+        msg = "Canvas API error {status_code}".format(status_code=e.status_code)
+        return JsonResponse({"message": msg}, status=500)
+
+    # assignment_ids = [assignment['id'] for assignment in assignments]
     # submissions = get_submissions_with_rubric_assessments(
     #     request_context,
     #     course,
@@ -29,7 +38,7 @@ def get_some_data(request):
         'submissions': [],
         'students': students,
     }
-    
+
     return JsonResponse(data)
 
 

--- a/rubric_visualization/decorators.py
+++ b/rubric_visualization/decorators.py
@@ -1,0 +1,55 @@
+from django.http import JsonResponse
+from canvas_oauth.oauth import get_oauth_token
+from canvas_oauth.exceptions import MissingTokenError, CanvasOAuthError
+
+
+def api_login_required(viewfunc):
+    """
+    Decorator that returns a 403 for unauthenticated API requests.
+    """
+
+    def wrap(request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return JsonResponse({"message": "Authentication required"}, status=403)
+        return viewfunc(request, *args, **kwargs)
+
+    wrap.__doc__ = viewfunc.__doc__
+    wrap.__name__ = viewfunc.__name__
+    return wrap
+
+
+def require_canvas_oauth_token(viewfunc):
+    """
+    Decorator that triggers oauth2 flow to obtain an auth token.
+
+    Expects the user to be authenticated, because the token is 
+    associated with that user. If the user does not have a token,
+    they will be redirected to Canvas to authorize the app. The
+    flow is handled by the canvas_oauth library.
+    """
+
+    def wrap(request, *args, **kwargs):
+        get_oauth_token(request)  # calling this method for its side-effect
+        return viewfunc(request, *args, **kwargs)
+
+    wrap.__doc__ = viewfunc.__doc__
+    wrap.__name__ = viewfunc.__name__
+    return wrap
+
+def api_canvas_oauth_token_exception(viewfunc):
+    """
+    Decorator that wraps exceptions raised by get_oauth_token(), otherwise
+    the exception will be handled by the middleware and trigger the oauth flow.
+    """
+
+    def wrap(request, *args, **kwargs):
+        try:
+            return viewfunc(request, *args, **kwargs)
+        except MissingTokenError:
+            return JsonResponse({"message": "Missing oauth token"}, status=403)
+        except CanvasOAuthError:
+            return JsonResponse({"message": "Failed to obtain OAuth token"}, status=500)
+
+    wrap.__doc__ = viewfunc.__doc__
+    wrap.__name__ = viewfunc.__name__
+    return wrap

--- a/rubric_visualization/requirements/base.txt
+++ b/rubric_visualization/requirements/base.txt
@@ -4,3 +4,4 @@ django-redis-cache==2.1.0
 redis==3.4.1
 hiredis==1.0.1
 git+https://github.com/penzance/canvas_python_sdk@v1.2.0#egg=canvas_python_sdk==1.2.0
+git+https://github.com/Harvard-University-iCommons/django-canvas-oauth.git@v1.0.0#egg=canvas-oauth

--- a/rubric_visualization/settings/base.py
+++ b/rubric_visualization/settings/base.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'canvas_oauth.apps.CanvasOAuthConfig',
     'frontend.apps.FrontendConfig',
     'rubric_data.apps.RubricDataConfig',
 ]
@@ -47,6 +48,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'canvas_oauth.middleware.OAuthMiddleware',
 ]
 
 ROOT_URLCONF = 'rubric_visualization.urls'
@@ -173,5 +175,14 @@ LOGGING = {
         },
     },
     'loggers': {
+        'canvas_oauth': {
+             'level': logging.DEBUG,
+             'handlers': ['default', 'console'],
+             'propagate': False,
+        }
     }
 }
+
+CANVAS_OAUTH_CLIENT_ID = SECURE_SETTINGS.get('canvas_oauth_client_id')
+CANVAS_OAUTH_CLIENT_SECRET = SECURE_SETTINGS.get('canvas_oauth_client_secret')
+CANVAS_OAUTH_CANVAS_DOMAIN = SECURE_SETTINGS.get('canvas_domain')

--- a/rubric_visualization/settings/base.py
+++ b/rubric_visualization/settings/base.py
@@ -19,12 +19,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = SECURE_SETTINGS.get('django_secret_key', 'changeme')
 
-# Canvas SDK settings
-# SDK_OAUTH_TOKEN = SECURE_SETTINGS.OAUTH_TOKEN
-# CANVAS_URL = SECURE_SETTINGS.CANVAS_URL
-SDK_OAUTH_TOKEN = SECURE_SETTINGS.get('OAUTH_TOKEN', '')
-CANVAS_URL = SECURE_SETTINGS.get('CANVAS_URL', '')
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = SECURE_SETTINGS.get('enable_debug', False)
 
@@ -179,10 +173,35 @@ LOGGING = {
              'level': logging.DEBUG,
              'handlers': ['default', 'console'],
              'propagate': False,
-        }
+        },
+        'frontend': {
+             'level': logging.DEBUG,
+             'handlers': ['default', 'console'],
+             'propagate': False,
+        },
+        'rubric_data': {
+             'level': logging.DEBUG,
+             'handlers': ['default', 'console'],
+             'propagate': False,
+        },
     }
 }
 
+# Canvas domain for authorizing and retrieving rubric data
+CANVAS_DOMAIN = SECURE_SETTINGS.get('canvas_domain', 'https://canvas.localhost')
+
+# Settings for canvas_oauth (https://github.com/harvard-university-icommons/django-canvas-oauth)
+# This library initiates the oauth2 flow for a user to obtain a token for API requests.
+CANVAS_OAUTH_CANVAS_DOMAIN = CANVAS_DOMAIN
 CANVAS_OAUTH_CLIENT_ID = SECURE_SETTINGS.get('canvas_oauth_client_id')
 CANVAS_OAUTH_CLIENT_SECRET = SECURE_SETTINGS.get('canvas_oauth_client_secret')
-CANVAS_OAUTH_CANVAS_DOMAIN = SECURE_SETTINGS.get('canvas_domain')
+
+# Settings for the canvas_sdk (https://github.com/penzance/canvas_python_sdk)
+# These settings can be passed to the sdk method functions or when creating
+# an instance of canvas_sdk.client.RequestContext().
+# Note: the `auth_token` is excluded because it should be obtained for each user.
+CANVAS_SDK_SETTINGS = {
+    'base_api_url': f"https://{CANVAS_DOMAIN}/api",
+    'max_retries': 3,
+    'per_page': 100,
+}

--- a/rubric_visualization/settings/secure.py.example
+++ b/rubric_visualization/settings/secure.py.example
@@ -1,6 +1,7 @@
 SECURE_SETTINGS = {
     'django_secret_key': 'keep-it-secret-keep-it-safe',
     'enable_debug': True,
-    'OAUTH_TOKEN': '',
-    'CANVAS_URL': ''
+    'canvas_oauth_client_id': '', # Canvas developer key
+    'canvas_oauth_client_secret': '', # Canvas developer key
+    'canvas_domain': '',
 }

--- a/rubric_visualization/templates/base.html
+++ b/rubric_visualization/templates/base.html
@@ -1,0 +1,14 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Rubric Visualization</title>
+  {% block styles %}{% endblock %}
+</head>
+<body>
+    {% block content %}{% endblock %}
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/rubric_visualization/templates/registration/login.html
+++ b/rubric_visualization/templates/registration/login.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+{% if form.errors %}
+<p>Your username and password didn't match. Please try again.</p>
+{% endif %}
+
+{% if next %}
+    {% if user.is_authenticated %}
+    <p>Your account doesn't have access to this page. To proceed,
+    please login with an account that has access.</p>
+    {% else %}
+    <p>Please login to see this page.</p>
+    {% endif %}
+{% endif %}
+
+<form method="post" action="{% url 'login' %}">
+{% csrf_token %}
+<table>
+<tr>
+    <td>{{ form.username.label_tag }}</td>
+    <td>{{ form.username }}</td>
+</tr>
+<tr>
+    <td>{{ form.password.label_tag }}</td>
+    <td>{{ form.password }}</td>
+</tr>
+</table>
+
+<input type="submit" value="login">
+<input type="hidden" name="next" value="{{ next }}">
+</form>
+
+{# Assumes you setup the password_reset view in your URLconf #}
+{# Commenting this out since we expect only superusers will use this for now #}
+{# <!-- <p><a href="{% url 'password_reset' %}">Lost password?</a></p> --> #}
+
+{% endblock %}

--- a/rubric_visualization/urls.py
+++ b/rubric_visualization/urls.py
@@ -16,7 +16,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+
 urlpatterns = [
+    path('accounts/', include('django.contrib.auth.urls')),
     path('admin/', admin.site.urls),
     path('data/', include('rubric_data.urls')),
     path('oauth/', include('canvas_oauth.urls')),

--- a/rubric_visualization/urls.py
+++ b/rubric_visualization/urls.py
@@ -19,5 +19,6 @@ from django.urls import include, path
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('data/', include('rubric_data.urls')),
+    path('oauth/', include('canvas_oauth.urls')),
     path('', include('frontend.urls'))
 ]


### PR DESCRIPTION
This PR adds [canvas-oauth](https://github.com/Harvard-University-iCommons/django-canvas-oauth) for obtaining per-user tokens.

**Notes:**

- Updated the project settings for both the oauth library and the SDK:
    - `CANVAS_URL` replaced by `canvas_domain`.
    - `OAUTH_TOKEN` removed, since it's now being obtained automatically in the view.
    -  SDK settings consolidated in `CANVAS_SDK_SETTINGS` (_base_api_url_, _per_page_, etc). 
- The `canvas_oauth` library requires an authenticated user, so the frontend view is now protected (requires login).
- Since we don't have LTI authentication yet, the default login has been enabled, allowing the user to login with a username and password. You'll have to create a django user (or superuser) to proceed.
- The initial frontend view is expected to initiate the oauth flow if the user's token is missing or expired. Assuming the user is already authenticated and a token has been saved to the database, then the frontend view should be rendered. At that point, the API view(s) should be able to retrieve the token from the database and proceed with the SDK requests.
- If for some reason the API view fails to obtain the token, it returns a JSON response with the error. The client will have to determine what to do at that point (maybe show an error and ask the user to re-login, which should trigger the oauth flow again).

Also note that you will need to do a `pip install` and `manage.py migrate` since this adds new dependencies and models.

@dodget Can you review when you have a chance? 