### PR TITLE
Lti integration

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -8,7 +8,7 @@ const App = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
-    fetch('data/some_data')
+    fetch(`data/${window.django.course_id}`)
       .then((response) => {
         if (response.status > 400) {
           return dispatch({ type: 'receivePayloadError' });

--- a/frontend/src/components/App.spec.js
+++ b/frontend/src/components/App.spec.js
@@ -10,6 +10,7 @@ describe('My Test Suite', () => {
   });
 
   it('Tests with axe-core', async (done) => {
+    global.django = {course_id: 12345};
     jest.setTimeout(10000);
     global.fetch = await mockFetchSuccess({
       assignments: [],

--- a/frontend/src/components/App.spec.js
+++ b/frontend/src/components/App.spec.js
@@ -10,7 +10,7 @@ describe('My Test Suite', () => {
   });
 
   it('Tests with axe-core', async (done) => {
-    global.django = {course_id: 12345};
+    global.django = { course_id: 12345 };
     jest.setTimeout(10000);
     global.fetch = await mockFetchSuccess({
       assignments: [],

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -3,5 +3,5 @@ from . import views
 
 
 urlpatterns = [
-    path('', views.index ),
+    path('', views.IndexView.as_view() ),
 ]

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -14,11 +14,12 @@ class IndexView(LTIAuthMixin, LoginRequiredMixin, TemplateView):
     template_name = 'frontend/index.html'
 
     def get_context_data(self, **kwargs):
-        # I'm getting the course ID by doing some hackery with a session attribute.
-        # There has to be a simpler way to get that value.
+        # If you want to get a specific LTI property ie 'custom_canvas_course_id'
+        # to be made available in self.request.session, you may need to add it
+        # to the list setting LTI_PROPERTY_LIST_EX
         # We will probably pass the role in the future as well. It may dictate 
         # what the user sees.
         return {
-            'course_id': self.request.session['launch_presentation_return_url'].split("/")[4],
+            'course_id': self.request.session['custom_canvas_course_id'],
             'is_student': self.lti.lis_result_sourcedid(self.request)
         }

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -1,11 +1,6 @@
-# from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from rubric_visualization.decorators import require_canvas_oauth_token
-
-
-
 from django.views.generic.base import TemplateView
 from lti_provider.mixins import LTIAuthMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -18,35 +13,8 @@ class IndexView(LTIAuthMixin, LoginRequiredMixin, TemplateView):
     template_name = 'frontend/index.html'
 
     def get_context_data(self, **kwargs):
-        print(self.request.session)
         return {
             'is_student': self.lti.lis_result_sourcedid(self.request),
             'course_title': self.lti.course_title(self.request),
             'number': 1
         }
-
-
-
-# @login_required
-# @require_canvas_oauth_token
-# @csrf_exempt
-# @xframe_options_exempt
-# def index(request, **kwargs):
-#     '''
-#     Processes launch request and redirects to appropriate view depending on the role of the launcher
-#     '''
-# 
-#     #True if this is a typical lti launch. False if not.
-#     is_basic_lti_launch = request.method == 'POST' and request.POST.get(
-#         'lti_message_type') == 'basic-lti-launch-request'
-# 
-#     context = {
-# 
-#     }
-# 
-#     print(request.user)
-# 
-#     # it should be possible here to pass some context based on the lti request
-#     # course_id, user "role"
-#     # we'll need to make sure users only see what they are supposed to
-#     return render(request, 'frontend/index.html')

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -1,9 +1,52 @@
-from django.contrib.auth.decorators import login_required
+# from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
+from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.decorators.csrf import csrf_exempt
 from rubric_visualization.decorators import require_canvas_oauth_token
 
 
-@login_required
-@require_canvas_oauth_token
-def index(request, **kwargs):
-    return render(request, 'frontend/index.html')
+
+from django.views.generic.base import TemplateView
+from lti_provider.mixins import LTIAuthMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.utils.decorators import method_decorator
+
+decorators = [csrf_exempt, xframe_options_exempt, require_canvas_oauth_token]
+@method_decorator(decorators, name='dispatch')
+class IndexView(LTIAuthMixin, LoginRequiredMixin, TemplateView):
+
+    template_name = 'frontend/index.html'
+
+    def get_context_data(self, **kwargs):
+        print(self.request.session)
+        return {
+            'is_student': self.lti.lis_result_sourcedid(self.request),
+            'course_title': self.lti.course_title(self.request),
+            'number': 1
+        }
+
+
+
+# @login_required
+# @require_canvas_oauth_token
+# @csrf_exempt
+# @xframe_options_exempt
+# def index(request, **kwargs):
+#     '''
+#     Processes launch request and redirects to appropriate view depending on the role of the launcher
+#     '''
+# 
+#     #True if this is a typical lti launch. False if not.
+#     is_basic_lti_launch = request.method == 'POST' and request.POST.get(
+#         'lti_message_type') == 'basic-lti-launch-request'
+# 
+#     context = {
+# 
+#     }
+# 
+#     print(request.user)
+# 
+#     # it should be possible here to pass some context based on the lti request
+#     # course_id, user "role"
+#     # we'll need to make sure users only see what they are supposed to
+#     return render(request, 'frontend/index.html')

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -1,10 +1,11 @@
-from django.views.decorators.clickjacking import xframe_options_exempt
-from django.views.decorators.csrf import csrf_exempt
-from rubric_visualization.decorators import require_canvas_oauth_token
-from django.views.generic.base import TemplateView
-from lti_provider.mixins import LTIAuthMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic.base import TemplateView
+
+from lti_provider.mixins import LTIAuthMixin
+from rubric_visualization.decorators import require_canvas_oauth_token
 
 decorators = [csrf_exempt, xframe_options_exempt, require_canvas_oauth_token]
 @method_decorator(decorators, name='dispatch')
@@ -13,8 +14,11 @@ class IndexView(LTIAuthMixin, LoginRequiredMixin, TemplateView):
     template_name = 'frontend/index.html'
 
     def get_context_data(self, **kwargs):
+        # I'm getting the course ID by doing some hackery with a session attribute.
+        # There has to be a simpler way to get that value.
+        # We will probably pass the role in the future as well. It may dictate 
+        # what the user sees.
         return {
-            'is_student': self.lti.lis_result_sourcedid(self.request),
-            'course_title': self.lti.course_title(self.request),
-            'number': 1
+            'course_id': self.request.session['launch_presentation_return_url'].split("/")[4],
+            'is_student': self.lti.lis_result_sourcedid(self.request)
         }

--- a/rubric_data/urls.py
+++ b/rubric_data/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 
-from .views import get_some_data
+from .views import course_data
 
 urlpatterns = [
-    path('some_data', get_some_data, name='some_data')
+    path('<int:course_id>/', course_data, name='course_data')
 ]

--- a/rubric_data/views.py
+++ b/rubric_data/views.py
@@ -18,8 +18,6 @@ def course_data(request, course_id):
     
     access_token = get_oauth_token(request)
     request_context = RequestContext(**settings.CANVAS_SDK_SETTINGS, auth_token=access_token)
-    # course = 53582 # this is the id for Zach's test class
-    course = 68667 # tylor's test course
 
     try:
         students = get_students_list(request_context, course_id)

--- a/rubric_data/views.py
+++ b/rubric_data/views.py
@@ -14,19 +14,20 @@ logger = logging.getLogger(__name__)
 
 @api_canvas_oauth_token_exception
 @api_login_required
-def get_some_data(request):
+def course_data(request, course_id):
     
     access_token = get_oauth_token(request)
     request_context = RequestContext(**settings.CANVAS_SDK_SETTINGS, auth_token=access_token)
-    course = 53582 # this is the id for Zach's test class
+    # course = 53582 # this is the id for Zach's test class
+    course = 68667 # tylor's test course
 
     try:
-        students = get_students_list(request_context, course)
-        assignments = get_assignments_list(request_context, course)
+        students = get_students_list(request_context, course_id)
+        assignments = get_assignments_list(request_context, course_id)
         assignment_ids = [assignment['id'] for assignment in assignments]
         submissions = get_submissions_with_rubric_assessments(
             request_context,
-            course,
+            course_id,
             assignment_ids
             )
     except CanvasAPIError as e:

--- a/rubric_visualization/requirements/base.txt
+++ b/rubric_visualization/requirements/base.txt
@@ -4,4 +4,6 @@ django-redis-cache==2.1.0
 redis==3.4.1
 hiredis==1.0.1
 git+https://github.com/penzance/canvas_python_sdk@v1.2.0#egg=canvas_python_sdk==1.2.0
-git+https://github.com/Harvard-University-iCommons/django-canvas-oauth.git@v1.0.0#egg=canvas-oauth
+-e ../django-canvas-oauth
+# git+https://github.com/Harvard-University-iCommons/django-canvas-oauth.git@v1.0.0#egg=canvas-oauth
+django-lti-provider==0.4.0

--- a/rubric_visualization/requirements/base.txt
+++ b/rubric_visualization/requirements/base.txt
@@ -6,5 +6,4 @@ hiredis==1.0.1
 git+https://github.com/penzance/canvas_python_sdk@v1.2.0#egg=canvas_python_sdk==1.2.0
 git+https://github.com/Harvard-University-iCommons/django-canvas-oauth.git@v1.1.0#egg=canvas-oauth
 # -e ../django-canvas-oauth
-# git+https://github.com/Harvard-University-iCommons/django-canvas-oauth.git@v1.0.0#egg=canvas-oauth
 django-lti-provider==0.4.0

--- a/rubric_visualization/requirements/base.txt
+++ b/rubric_visualization/requirements/base.txt
@@ -5,5 +5,4 @@ redis==3.4.1
 hiredis==1.0.1
 git+https://github.com/penzance/canvas_python_sdk@v1.2.0#egg=canvas_python_sdk==1.2.0
 git+https://github.com/Harvard-University-iCommons/django-canvas-oauth.git@v1.1.0#egg=canvas-oauth
-# -e ../django-canvas-oauth
 django-lti-provider==0.4.0

--- a/rubric_visualization/settings/base.py
+++ b/rubric_visualization/settings/base.py
@@ -14,7 +14,6 @@ import os
 import logging
 from .secure import SECURE_SETTINGS
 
-# ALLOWED_HOSTS = ['.harvard.edu']
 CSRF_TRUSTED_ORIGINS = ['canvas.harvard.edu']
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -217,6 +216,9 @@ PYLTI_CONFIG = {
 }
 
 X_FRAME_OPTIONS = SECURE_SETTINGS.get('X_FRAME_OPTIONS', 'ALLOW-FROM https://canvas.harvard.edu')
+
+# This setting will add an LTI property to the session
+LTI_PROPERTY_LIST_EX = ['custom_canvas_course_id']
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',

--- a/rubric_visualization/settings/base.py
+++ b/rubric_visualization/settings/base.py
@@ -14,6 +14,9 @@ import os
 import logging
 from .secure import SECURE_SETTINGS
 
+# ALLOWED_HOSTS = ['.harvard.edu']
+CSRF_TRUSTED_ORIGINS = ['canvas.harvard.edu']
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -32,6 +35,7 @@ INSTALLED_APPS = [
     'canvas_oauth.apps.CanvasOAuthConfig',
     'frontend.apps.FrontendConfig',
     'rubric_data.apps.RubricDataConfig',
+    'lti_provider',
 ]
 
 MIDDLEWARE = [
@@ -187,6 +191,40 @@ LOGGING = {
     }
 }
 
+# LTI configuration
+
+LTI_TOOL_CONFIGURATION = {
+    'title': 'Rubric Visualization',
+    'description': 'An LTI-compliant tool that enables instructors and administrators to visualize rubric data.',
+    'launch_url': 'lti/',
+    'embed_url': '',
+    'embed_icon_url': '',
+    'embed_tool_id': '',
+    'landing_url': '/',
+    'navigation': True,
+    'new_tab': False,
+    'course_aware': False,
+}
+
+
+PYLTI_CONFIG = {
+    'consumers': {
+        SECURE_SETTINGS['consumer_key']: {
+            'secret': SECURE_SETTINGS['lti_secret']
+        }
+    }
+}
+
+X_FRAME_OPTIONS = SECURE_SETTINGS.get('X_FRAME_OPTIONS', 'ALLOW-FROM https://canvas.harvard.edu')
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'lti_provider.auth.LTIBackend',
+]
+
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+SESSION_COOKIE_SAMESITE = None
+
 # Canvas domain for authorizing and retrieving rubric data
 CANVAS_DOMAIN = SECURE_SETTINGS.get('canvas_domain', 'https://canvas.localhost')
 
@@ -195,6 +233,14 @@ CANVAS_DOMAIN = SECURE_SETTINGS.get('canvas_domain', 'https://canvas.localhost')
 CANVAS_OAUTH_CANVAS_DOMAIN = CANVAS_DOMAIN
 CANVAS_OAUTH_CLIENT_ID = SECURE_SETTINGS.get('canvas_oauth_client_id')
 CANVAS_OAUTH_CLIENT_SECRET = SECURE_SETTINGS.get('canvas_oauth_client_secret')
+
+CANVAS_OAUTH_SCOPES = [
+    'url:GET|/api/v1/courses/:course_id/assignments',
+    'url:GET|/api/v1/courses/:course_id/users',
+    'url:GET|/api/v1/courses/:course_id/assignments/:assignment_id/submissions',
+    'url:GET|/api/v1/courses/:course_id/rubrics',
+    'url:GET|/api/v1/courses/:course_id/rubrics/:id',
+]
 
 # Settings for the canvas_sdk (https://github.com/penzance/canvas_python_sdk)
 # These settings can be passed to the sdk method functions or when creating

--- a/rubric_visualization/settings/base.py
+++ b/rubric_visualization/settings/base.py
@@ -237,14 +237,7 @@ CANVAS_OAUTH_CLIENT_SECRET = SECURE_SETTINGS.get('canvas_oauth_client_secret')
 CANVAS_OAUTH_SCOPES = [
     'url:GET|/api/v1/courses/:course_id/assignments',
     'url:GET|/api/v1/courses/:course_id/users',
-    'url:GET|/api/v1/courses/:course_id/assignments/:assignment_id/submissions',
-    'url:GET|/api/v1/courses/:course_id/rubrics',
-    'url:GET|/api/v1/courses/:course_id/rubrics/:id',
-]
-
-CANVAS_OAUTH_SCOPES = [
-    'url:GET|/api/v1/courses/:course_id/assignments',
-    'url:GET|/api/v1/courses/:course_id/users',
+    'url:GET|/api/v1/courses/:course_id/students',
     'url:GET|/api/v1/courses/:course_id/assignments/:assignment_id/submissions',
     'url:GET|/api/v1/courses/:course_id/rubrics',
     'url:GET|/api/v1/courses/:course_id/rubrics/:id',

--- a/rubric_visualization/settings/secure.py.example
+++ b/rubric_visualization/settings/secure.py.example
@@ -4,4 +4,6 @@ SECURE_SETTINGS = {
     'canvas_oauth_client_id': '', # Canvas developer key
     'canvas_oauth_client_secret': '', # Canvas developer key
     'canvas_domain': '',
+    'consumer_key': 'some-key',
+    'lti_secret': 'some-secret'
 }

--- a/rubric_visualization/templates/frontend/index.html
+++ b/rubric_visualization/templates/frontend/index.html
@@ -13,7 +13,7 @@
 {% load static %}
 <script>
     window.django = {
-        randomValue: 1234,
+        course_id: {{ course_id }}
     };
 </script>
 <script src="{% static 'frontend/main.js' %}"></script>

--- a/rubric_visualization/urls.py
+++ b/rubric_visualization/urls.py
@@ -1,26 +1,14 @@
 """rubric_visualization URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.0/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
 from django.urls import include, path
 
 
 urlpatterns = [
-    path('accounts/', include('django.contrib.auth.urls')),
+    # path('accounts/', include('django.contrib.auth.urls')),
+    path('', include('frontend.urls')),
     path('admin/', admin.site.urls),
     path('data/', include('rubric_data.urls')),
     path('oauth/', include('canvas_oauth.urls')),
-    path('', include('frontend.urls'))
+    path('lti/', include('lti_provider.urls')),
 ]


### PR DESCRIPTION
This PR resolves ATGU-2108 (Setup lti so users can authenticate via canvas) by:

- Adding the `django-lti-provider` package
- Configuring settings and urls to leverage `django-lti-provider` to integrate the application as an lti
- Adding `course_id` from the lti to the global js context, and requesting data pertaining to that `course_id`
- Commenting out the `accounts/` url, as users are now authenticated via canvas

Notes:

1. I am getting the `course_id` in the `get_context_data` life cycle method of the IndexView. However, it involves hackery `'course_id': self.request.session['launch_presentation_return_url'].split("/")[4]`, as I didn't find a simpler way to grab that piece of data from somewhere. That is getting a url which contains the course_id, then just grabbing the id out of it. I assume there is a better way to do that, so feedback would be appreciated.
2. Since the backend is now moving closer to its final direction, its probably high-time to start writing some tests. I can begin writing tests, but I thought it would be good to get this reviewed earlier rather than later.