### PR TITLE
Upgrade to djago 3.2 lts

### DIFF
--- a/rubric_visualization/requirements/base.txt
+++ b/rubric_visualization/requirements/base.txt
@@ -1,4 +1,4 @@
-Django~=3.1.0
+Django~=3.2.0
 psycopg2==2.8.4
 django-redis-cache==2.1.0
 redis==3.4.1

--- a/rubric_visualization/settings/base.py
+++ b/rubric_visualization/settings/base.py
@@ -259,3 +259,5 @@ CANVAS_SDK_SETTINGS = {
     'max_retries': 3,
     'per_page': 100,
 }
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
This PR resolves [ATGU-2996](https://jira.huit.harvard.edu/browse/ATGU-2996) by:

- Upgrading django to `~=3.2.0`
- Adding the `DEFAULT_AUTO_FIELD` to the base settings


## Notes
- I chose to do this upgrade on rubric vis because it was already on django 3.1, so it was the simplest path.
- Looks like another simple upgrade process, that seems to change things that we don't leverage.